### PR TITLE
updated two readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ make down; make up; make up-open-webui
 ```
 
 ## Running with OAuth
-Since the OpenWebUI uses Keycloak on both server side and browser side, you need to create a host mapping for `keycloak`.
+Since the OpenWebUI uses Keycloak on both server side and browser side, you **MUST** to create a host mapping for `keycloak`.
 
-On Macs, this can be done by adding an entry to `/etc/hosts`:
+On Macs, this is done by adding an entry to `/etc/hosts`. This is likely a `sudo` operation so you may need to run `sudo nano /etc/hosts` or `sudo vi /etc/hosts` (depending on your preferred editor) and add the following line:
 
 ```sh
 127.0.0.1   keycloak
@@ -117,6 +117,8 @@ Then run:
 ```shell
 make down; make up; make up-open-webui-auth
 ```
+
+For more details and getting the models list up and running, refer to the [openwebui_functions/readme.md](openwebui_functions/readme.md).
 
 ## Contributing
 

--- a/openwebui_functions/readme.md
+++ b/openwebui_functions/readme.md
@@ -4,7 +4,8 @@
 https://docs.openwebui.com/features/plugin/functions/pipe/
 
 ## Instructions to add pipe to OpenWebUI on local machine
-- Run `make down; make up-open-webui-auth` to start OpenWebUI with authenticatio
+- Run `make down; make up-open-webui-auth` to start OpenWebUI with authentication
+  - Refer to base level README.md for instructions on setting up OAuth if you haven't already. Specifically, the keycloak host mapping in /etc/hosts.
 - Login with admin/password to openwebui 
 - Now run `make set-admin-user-role` to set the admin role for this new user
 - Reload the OpenWebUI page in your browser


### PR DESCRIPTION
This pull request improves the documentation for setting up OAuth and using OpenWebUI with authentication, making the setup steps clearer and easier to follow. The most important changes are grouped below:

**OAuth Setup Clarifications:**

* Updated the `README.md` to emphasize that creating a host mapping for `keycloak` is mandatory, and clarified that editing `/etc/hosts` on Mac requires `sudo` privileges. The instructions now specify which editors and the exact line to add.

**Authentication and Model Setup Guidance:**

* Added a reference in `README.md` to the `openwebui_functions/readme.md` for further details on getting the models list up and running, improving discoverability of advanced setup steps.
* Improved the instructions in `openwebui_functions/readme.md` by correcting a typo and adding a note to refer to the base README for OAuth setup, specifically the keycloak host mapping step.