### PR TITLE
Prevent logging of non-text responses

### DIFF
--- a/docker-compose-openwebui.yml
+++ b/docker-compose-openwebui.yml
@@ -76,11 +76,10 @@ services:
       ENABLE_API_KEY: True
       # Use S3 for file storage: https://docs.openwebui.com/tutorials/s3-storage/
       STORAGE_PROVIDER: s3
-#      S3_ENDPOINT_URL: "https://bwell-services-data-science-ue1.s3.us-east-1.amazonaws.com"
-      S3_ENDPOINT_URL: "https://bwell-dev-data-science-ue1.s3.us-east-1.amazonaws.com/"
-      S3_BUCKET_NAME: "aiden"
+      S3_ENDPOINT_URL: "https://s3.us-east-1.amazonaws.com"
+      S3_BUCKET_NAME: "bwell-dev-data-science-ue1"
       S3_REGION_NAME: "us-east-1"
-      S3_KEY_PREFIX: "uploads/"
+      S3_KEY_PREFIX: "aiden/uploads/"
       # Embeddings config
 #      BYPASS_EMBEDDING_AND_RETRIEVAL: True
 #      RAG_EMBEDDING_ENGINE: "openai"

--- a/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
+++ b/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
@@ -53,8 +53,12 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
 
         if logger.isEnabledFor(logging.DEBUG):
             content_type = response.headers.get("content-type", "")
-            is_text = content_type.startswith("text/") or content_type.startswith(
-                "application/json"
+            is_text = (
+                content_type.startswith("text/")
+                or content_type.startswith("application/json")
+                or content_type.startswith("application/xml")
+                or content_type.startswith("application/yaml")
+                or content_type.startswith("application/x-www-form-urlencoded")
             )
             # if response is StreamingResponse, we need to read the body
             if "body_iterator" in response.__dict__:

--- a/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
+++ b/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
@@ -50,6 +50,10 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
         process_time_in_secs = f"{process_time:.4f} secs"
 
         res_body_text: str = "No body"
+        content_type = response.headers.get("content-type", "")
+        is_text = content_type.startswith("text/") or content_type.startswith(
+            "application/json"
+        )
         # if response is StreamingResponse, we need to read the body
         if "body_iterator" in response.__dict__:
             response1: StreamingResponse = cast(StreamingResponse, response)
@@ -58,25 +62,30 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
             ]
             response1.body_iterator = iterate_in_threadpool(iter(res_body))
             if len(res_body) > 0:
-                # Turn response body object to string
                 res_body_ = res_body[0]
-                res_body_text = (
-                    res_body_.decode()
-                    if isinstance(res_body_, bytes)
-                    else str(res_body_)
-                )
+                if is_text:
+                    res_body_text = (
+                        res_body_.decode()
+                        if isinstance(res_body_, bytes)
+                        else str(res_body_)
+                    )
+                else:
+                    res_body_text = (
+                        f"Non-text response: {content_type}, {len(res_body_)} bytes"
+                    )
         else:
             if response.body:
-                # For regular responses, we can access the body directly
                 res_body2: list[bytes | memoryview] = [response.body]
-                # Turn response body object to string
                 if len(res_body2) > 0:
                     res_body_2 = res_body2[0]
-                    res_body_text = (
-                        res_body_2.decode()
-                        if isinstance(res_body_2, bytes)
-                        else str(res_body_2)
-                    )
+                    if is_text:
+                        res_body_text = (
+                            res_body_2.decode()
+                            if isinstance(res_body_2, bytes)
+                            else str(res_body_2)
+                        )
+                    else:
+                        res_body_text = f"Non-text response: {content_type}, {len(res_body_2)} bytes"
 
         if response.status_code >= 300:
             logger.error(
@@ -94,18 +103,19 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
                 f"\n==== End of Response Body ======"
             )
         else:
-            logger.debug(
-                f"\n==== Request: {request.method} {request.url} ======"
-                f"\n===== Headers ======"
-                f"\n{request.headers}"
-                f"\n====== Request Body ====="
-                f"\n{json.dumps(req_body)}"
-                f"\n==== End of Request Body ======"
-            )
-            logger.debug(
-                f"\n====== Response: {response.status_code} {request.method} {request.url} (time: {process_time_in_secs}) ======"
-                f"\n==== Response Body ======"
-                f"\n{res_body_text}"
-                f"\n==== End of Response Body ======"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"\n==== Request: {request.method} {request.url} ======"
+                    f"\n===== Headers ======"
+                    f"\n{request.headers}"
+                    f"\n====== Request Body ====="
+                    f"\n{json.dumps(req_body)}"
+                    f"\n==== End of Request Body ======"
+                )
+                logger.debug(
+                    f"\n====== Response: {response.status_code} {request.method} {request.url} (time: {process_time_in_secs}) ======"
+                    f"\n==== Response Body ======"
+                    f"\n{res_body_text}"
+                    f"\n==== End of Response Body ======"
+                )
         return response

--- a/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
+++ b/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
@@ -76,8 +76,13 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
                             else str(res_body_)
                         )
                     else:
+                        # Safely get length if possible
+                        try:
+                            body_len = len(res_body_)
+                        except TypeError:
+                            body_len = None
                         res_body_text = (
-                            f"Non-text response: {content_type}, {len(res_body_)} bytes"
+                            f"Non-text response: {content_type}, {body_len} bytes"
                         )
             else:
                 if response.body:
@@ -91,7 +96,13 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
                                 else str(res_body_2)
                             )
                         else:
-                            res_body_text = f"Non-text response: {content_type}, {len(res_body_2)} bytes"
+                            try:
+                                body_len2 = len(res_body_2)
+                            except TypeError:
+                                body_len2 = None
+                            res_body_text = (
+                                f"Non-text response: {content_type}, {body_len2} bytes"
+                            )
 
         if response.status_code >= 300:
             logger.error(

--- a/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
+++ b/language_model_gateway/gateway/middleware/fastapi_logging_middleware.py
@@ -50,42 +50,44 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
         process_time_in_secs = f"{process_time:.4f} secs"
 
         res_body_text: str = "No body"
-        content_type = response.headers.get("content-type", "")
-        is_text = content_type.startswith("text/") or content_type.startswith(
-            "application/json"
-        )
-        # if response is StreamingResponse, we need to read the body
-        if "body_iterator" in response.__dict__:
-            response1: StreamingResponse = cast(StreamingResponse, response)
-            res_body: list[str | bytes | memoryview] = [
-                section async for section in response1.body_iterator
-            ]
-            response1.body_iterator = iterate_in_threadpool(iter(res_body))
-            if len(res_body) > 0:
-                res_body_ = res_body[0]
-                if is_text:
-                    res_body_text = (
-                        res_body_.decode()
-                        if isinstance(res_body_, bytes)
-                        else str(res_body_)
-                    )
-                else:
-                    res_body_text = (
-                        f"Non-text response: {content_type}, {len(res_body_)} bytes"
-                    )
-        else:
-            if response.body:
-                res_body2: list[bytes | memoryview] = [response.body]
-                if len(res_body2) > 0:
-                    res_body_2 = res_body2[0]
+
+        if logger.isEnabledFor(logging.DEBUG):
+            content_type = response.headers.get("content-type", "")
+            is_text = content_type.startswith("text/") or content_type.startswith(
+                "application/json"
+            )
+            # if response is StreamingResponse, we need to read the body
+            if "body_iterator" in response.__dict__:
+                response1: StreamingResponse = cast(StreamingResponse, response)
+                res_body: list[str | bytes | memoryview] = [
+                    section async for section in response1.body_iterator
+                ]
+                response1.body_iterator = iterate_in_threadpool(iter(res_body))
+                if len(res_body) > 0:
+                    res_body_ = res_body[0]
                     if is_text:
                         res_body_text = (
-                            res_body_2.decode()
-                            if isinstance(res_body_2, bytes)
-                            else str(res_body_2)
+                            res_body_.decode()
+                            if isinstance(res_body_, bytes)
+                            else str(res_body_)
                         )
                     else:
-                        res_body_text = f"Non-text response: {content_type}, {len(res_body_2)} bytes"
+                        res_body_text = (
+                            f"Non-text response: {content_type}, {len(res_body_)} bytes"
+                        )
+            else:
+                if response.body:
+                    res_body2: list[bytes | memoryview] = [response.body]
+                    if len(res_body2) > 0:
+                        res_body_2 = res_body2[0]
+                        if is_text:
+                            res_body_text = (
+                                res_body_2.decode()
+                                if isinstance(res_body_2, bytes)
+                                else str(res_body_2)
+                            )
+                        else:
+                            res_body_text = f"Non-text response: {content_type}, {len(res_body_2)} bytes"
 
         if response.status_code >= 300:
             logger.error(


### PR DESCRIPTION
This PR fixes image generation by preventing logging of non-text response bodies and updates S3 configuration for OpenWebUI. The fix addresses an issue where binary content (like images) was being logged as text, which could cause problems.

Added content-type checking to avoid logging binary responses as text
Updated S3 configuration to use proper bucket structure with key prefix
Wrapped debug logging in conditional check for better performance